### PR TITLE
fix: fixed green artifacts with FilterLibrary + pyramid mipmap clamp fix

### DIFF
--- a/RetroVisor/GPU/Sankara.metal
+++ b/RetroVisor/GPU/Sankara.metal
@@ -78,9 +78,8 @@ namespace sankara {
     }
 
     inline Color3 sampleYCC(texture2d<half> tex, sampler sam, float2 uv, float mipLevel = 0) {
-
-        float2 clampedUV = clamp(uv, float2(0.01, 0.01), float2(0.99, 0.99));
-        return tex.sample(sam, clampedUV, level(mipLevel)).rgb + Color3(0.0, -0.5, -0.5);
+        
+        return tex.sample(sam, uv, level(mipLevel)).rgb + Color3(0.0, -0.5, -0.5);
     }
     
     //

--- a/RetroVisor/Shaders/FilterLibrary.swift
+++ b/RetroVisor/Shaders/FilterLibrary.swift
@@ -49,6 +49,7 @@ class ResampleFilter {
 
             filter.scaleTransform = transformPtr
             filter.encode(commandBuffer: commandBuffer, sourceTexture: input, destinationTexture: output)
+            filter.scaleTransform = nil
         }
     }
     
@@ -112,12 +113,15 @@ class BlurFilter {
             switch blurType {
             case .box:
                 let filter = MPSImageBox(device: output.device, kernelWidth: rw, kernelHeight: rh)
+                filter.edgeMode = .clamp
                 filter.encode(commandBuffer: commandBuffer, sourceTexture: input, destinationTexture: output)
             case .tent:
                 let filter = MPSImageTent(device: output.device, kernelWidth: rw, kernelHeight: rh)
+                filter.edgeMode = .clamp
                 filter.encode(commandBuffer: commandBuffer, sourceTexture: input, destinationTexture: output)
             case .gaussian:
                 let filter = MPSImageGaussianBlur(device: output.device, sigma: sigma)
+                filter.edgeMode = .clamp
                 filter.encode(commandBuffer: commandBuffer, sourceTexture: input, destinationTexture: output)
             }
         }

--- a/RetroVisor/Shaders/Sankara.swift
+++ b/RetroVisor/Shaders/Sankara.swift
@@ -557,6 +557,7 @@ final class Sankara: Shader {
         blurFilter = BlurFilter()
         dilationFilter = DilationFilter()
         pyramid = MPSImageGaussianPyramid(device: ShaderLibrary.device)
+        pyramid.edgeMode = .clamp
     }
     
     func updateTextures(commandBuffer: MTLCommandBuffer, in input: MTLTexture, out output: MTLTexture) {


### PR DESCRIPTION
*Disclaimer I can barely write a "Hello World!" in either Swift or Metal.

Thanks to some experience with After Effects and its blurs, I was able to figure out how to border pixel tiling during blurs happen, and was able to fix it at `ycc`, `CV_ENABLE` & `SCANLINE_ENABLE` level.

- put in place `.clamp` right after pyramid mipmaps generation
- put in place `.clamp` right after box, tent & gaussian blurs are calculated
- reverted commit `54611a2c` in case you find this fix sufficient!

Please find the reference images below!